### PR TITLE
authenticate_as fixes

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -66,5 +66,11 @@ Application.put_env(:auth_test_support, Endpoint, [secret_key_base: "foobar"])
 
 defmodule Endpoint do
   use Phoenix.Endpoint, otp_app: :auth_test_support
+
+  plug Plug.Session,
+    store: :cookie,
+    key: "_test",
+    signing_salt: "foobar"
+
   plug Router
 end


### PR DESCRIPTION
authenticate_as can now take a generic endpoint as well as delegate to
the assumed present `@endpoint` value.
