### PR TITLE
Renamed sign_in and changed authorize_as

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule AuthTestSupport.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:phoenix, "1.1.2", only: :test},
+     {:plug, "> 0.0.0"},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.11", only: :dev},
      {:ecto, "1.1.4", only: :test}]


### PR DESCRIPTION
`authenticate_as/*` was removed
`authorize_as/2` will simply assign the account in the `conn`
`sign_in/2` is now `authenticate_as/2`
